### PR TITLE
[core] Laziness is not our friend here.

### DIFF
--- a/src/think/resource/core.clj
+++ b/src/think/resource/core.clj
@@ -32,7 +32,7 @@
   "Ignore these resources for which pred returns true and do not track them.
   They will not be released unless added again with track"
   [pred]
-  (swap! *resource-context* #(remove pred %)))
+  (swap! *resource-context* #(doall (remove pred %))))
 
 
 (defn ignore


### PR DESCRIPTION
If these `remove`s pile up too deep, the eventual realization of this sequence can throw inscrutable stack-overflow exceptions in the caller's innocent code.